### PR TITLE
feature: evergreen language inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,10 @@ To enable syntax highlighting for languages, use the language option:
   };
 }
 ```
-- All available languages are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#languages) with the following note
-  - The language name is simply just everything after `language_`
+- All available languages are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#languages)
 
 ### Evergreen
-[Evergreen](https://github.com/Evergreen-lxl/Evergreen.lxl) adds support for syntax highlighting with Treesitter. This allows for finer and more intelligent highlighting, but the number available [languages](https://github.com/Evergreen-lxl/evergreen-languages) is far lesser than Lite-XL regex-style highlighting.
+[Evergreen](https://github.com/Evergreen-lxl/Evergreen.lxl) adds support for syntax highlighting with Treesitter. This allows for more intelligent highlighting, but the number available [languages](https://github.com/Evergreen-lxl/evergreen-languages) is far lesser than Lite-XL regex-style highlighting.
 
 To enable it, use the option:
 ```nix
@@ -70,10 +69,15 @@ To enable it, use the option:
     enable = true;
     plugins.evergreen = {
       enableList = [ "html" "lua" ];
+      copyLanguages = false;
     };
   };
 }
 ```
+
+`evergreen` still needs to be added to the plugins enableList to get loaded.
+
+Enabling `copyLanguages` will attempt to enable each Evergreen language in your Lite-XL languages.
 
 ## Plugins
 To enable plugins, use the plugin option:
@@ -86,12 +90,16 @@ To enable plugins, use the plugin option:
   };
 }
 ```
-- All available plugins are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#plugins) with the following notes:
-  - Plugin names are exactly as they appear in the repository.
+- All available plugins are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#plugins)
   - `ide_*` plugins are not included since they are all links to the same `ide` plugin.
 
+### LSP
+When languages are specified, the appropriate language servers and linters (if `lintplus` is in the plugins enableList) will be automatically added to your `home.packages` if you enable `lite-xl.plugins.lsp.addPackages`.
+
+`lsp` still needs to be added to the plugins enableList to get loaded.
+
 ## Libraries
-To enable plugins, use the plugin option:
+To enable plugins, use the library option:
 ```nix
 # home.nix
 {
@@ -101,10 +109,7 @@ To enable plugins, use the plugin option:
   };
 }
 ```
-- All available libraries are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#libraries) exactly as they appear.
-
-## LSP Plugin
-When languages are specified, the appropriate language servers and linters (if you enabled liteplus) will be automatically added to your `home.packages` if you enable `lite-xl.plugins.lsp.addPackages`
+- All available libraries are on the [official plugin repository](https://github.com/lite-xl/lite-xl-plugins?tab=readme-ov-file#libraries)
 
 # Todo
 Fonts:
@@ -137,6 +142,4 @@ Maybes:
 - Figure out a better way to source versions than packing everything into one nvfetcher.toml. It just needs to avoid getting rate-limited
 - Switch everything from fetchgit to fetchFromGitHub where applicable
 - Custom themes. I am not creating a theme designer
-- Evergreen language inheritance. If enabled, it will enable (if it exists) the Evergreen language for each syntax language enabled
-  - ? Exclusion
 

--- a/modules/libraries/libraries.nix
+++ b/modules/libraries/libraries.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) getPackageSrc mergeAttrsList;
 
-  lsp = lib.NXL.lsp;
+  lsp = lib.NXLPkgs.lsp;
 in
 mergeAttrsList [
   lib.NXLPkgs.libraries

--- a/modules/plugins/evergreen/default.nix
+++ b/modules/plugins/evergreen/default.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  inherit (lib) subImport genNamedPaths mkLuaScript mkIf mkOption types attrNames getAttrs mergeAttrsList optionalAttrs length;
+  inherit (lib) subImport genNamedPaths mkLuaScript mkIf mkOption mkEnableOption types attrNames mergeAttrsList optionalAttrs length;
   cfg = config.programs.lite-xl;
 
   enableLanguages = subImport ./pack.nix;
@@ -22,6 +22,13 @@ in
       customEnableList = mkOption {
         type = types.attrsOf types.path;
         default = { };
+      };
+      copyLanguages = {
+        enable = mkEnableOption "copying Lite-XL languages for Evergreen";
+        filter = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+        };
       };
     };
   };

--- a/modules/plugins/evergreen/pack.nix
+++ b/modules/plugins/evergreen/pack.nix
@@ -1,15 +1,20 @@
 { config, lib, ... }:
 let
-  inherit (lib) subImport mapGetDeps getAttrs attrNames flatten mergeAttrsList;
+  inherit (lib) subImport mapGetDeps intersectLists subtractLists optional getAttrs attrNames flatten mergeAttrsList;
   cfg = config.programs.lite-xl;
+  cl = cfg.plugins.evergreen.copyLanguages;
 
   supportedLanguages = subImport ./languages.nix;
   depsList = subImport ./deps.nix;
 
   customEnableList = cfg.plugins.evergreen.customEnableList;
 
-  # Filter enabled languages
-  enableList = cfg.plugins.evergreen.enableList;
+  # Filter and add supported languages if evergreen.copyLanguages is enabled
+  languageCopy = intersectLists cfg.plugins.languages.enableList (attrNames supportedLanguages);
+  filterCopy = subtractLists cl.filter languageCopy;
+  copyLanguages = optional cl.enable filterCopy;
+
+  enableList = flatten (cfg.plugins.evergreen.enableList ++ copyLanguages);
   languagesWithDepsStrings = attrNames (getAttrs enableList depsList.plugins);
 
   # Get language deps

--- a/modules/plugins/languages/external.nix
+++ b/modules/plugins/languages/external.nix
@@ -1,13 +1,20 @@
 { lib, pkgs, ... }:
 let
-  inherit (lib) getPackageSrc;
+  inherit (lib) genPaths getPackageSrc mergeAttrsList;
+
+  builtinLangs = genPaths "${lib.NXLPkgs.lxl}/data/plugins/language_" [
+    "c" "cpp" "css" "html" "js" "lua" "md" "python" "xml"
+  ];
 in
-{
-  "containerfile" = "${getPackageSrc "plg-containerfile" pkgs}/init.lua";
-  "crystal" = "${getPackageSrc "plg-crystal" pkgs}/language_crystal.lua";
-  "ksy" = "${getPackageSrc "plg-ksy" pkgs}/plugins/language_ksy.lua";
-  "pony" = "${getPackageSrc "plg-pony" pkgs}/language_pony.lua";
-  "vale" = "${getPackageSrc "plg-vale" pkgs}/language_vale.lua";
-  "yuescript" = "${getPackageSrc "plg-yuescript" pkgs}/language_yuescript.lua";
-}
+mergeAttrsList [
+  builtinLangs
+  {
+    containerfile = "${getPackageSrc "plg-containerfile" pkgs}/init.lua";
+    crystal = "${getPackageSrc "plg-crystal" pkgs}/language_crystal.lua";
+    ksy = "${getPackageSrc "plg-ksy" pkgs}/plugins/language_ksy.lua";
+    pony = "${getPackageSrc "plg-pony" pkgs}/language_pony.lua";
+    vale = "${getPackageSrc "plg-vale" pkgs}/language_vale.lua";
+    yuescript = "${getPackageSrc "plg-yuescript" pkgs}/language_yuescript.lua";
+  }
+]
 

--- a/modules/plugins/languages/pack.nix
+++ b/modules/plugins/languages/pack.nix
@@ -16,7 +16,7 @@ let
     "tcl" "teal" "tex" "toml" "ts" "tsx" "typst" "umka" "v" "wren" "yaml" "zig"
   ];
 
-  languagePaths = genPluginPaths "${lib.NXLPkgs.lxl}/plugins/language_" languageNames [ ] (subImport ./external.nix);
+  languagePaths = genPluginPaths "${lib.NXLPkgs.lxp}/plugins/language_" languageNames [ ] (subImport ./external.nix);
 in
 languagePaths
 

--- a/modules/plugins/plugins.nix
+++ b/modules/plugins/plugins.nix
@@ -81,7 +81,7 @@ let
 
   pluginDirs = [ "editorconfig" "profile" ];
 
-  pluginPaths = genPluginPaths "${lib.NXLPkgs.lxl}/plugins/" pluginFiles pluginDirs (subImport ./external.nix);
+  pluginPaths = genPluginPaths "${lib.NXLPkgs.lxp}/plugins/" pluginFiles pluginDirs (subImport ./external.nix);
 in
 pluginPaths
 

--- a/parts/lib.nix
+++ b/parts/lib.nix
@@ -38,6 +38,13 @@ extend (final: _: {
   in
   pkgs.${overridePkg}.overrideAttrs { inherit version src; };
 
+  # Generate attrset of names to a source
+  # -> {
+  #   name1 = "<source1>.lua";
+  #   name2 = "<source2>/";
+  # }
+  genPaths = source: names: genAttrs names (plugin: "${source}${plugin}.lua");
+
   # Generate attrset of paths to a source
   # -> {
   #   /path/to/path1.lua = "<source1>.lua";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,8 +23,8 @@ in rec {
     # www = packagerGit "lib-www" ./www.nix pkgs;
     # TODO: Build nonicons because it is not in Nixpkgs
     # https://github.com/ya2s/nonicons/
-    font_nonicons = pkgs.callPackage ./font_nonicons.nix { src = lxl; };
-    font_symbols_nerdfont_mono_regular = pkgs.callPackage ./font_symbols_nerdfont_mono_regular.nix { src = lxl; };
+    font_nonicons = pkgs.callPackage ./font_nonicons.nix { src = lxp; };
+    font_symbols_nerdfont_mono_regular = pkgs.callPackage ./font_symbols_nerdfont_mono_regular.nix { src = lxp; };
   };
 }
 


### PR DESCRIPTION
Evergreen can inherit the languages from plugins.languages.enableList and will enable the appropriate Evergreen languages if they exist