### PR TITLE
refactor: plugin/library dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,6 @@ Main:
       - Make this configurable?
 - LSP
   - Inherit lite-xl languages for LSP like with Evergreen. Would need a way to key language names to LSPs
-- Libraries
-  - Dep res does not catch libraries from exclusively resolved plugins (plugins not in enableList). I think a better approach would be to go over every enabled plugin/library, and for each resolved dep, resolve both plugin and library deps at the same time. Need to keep the resolved library and plugin lists separate somehow
-    - This would also natively allow library with plugin dependencies, even though that is not implemented
 - Fonts
   - [x] Defined fonts
   - [x] Custom fonts

--- a/modules/deps.nix
+++ b/modules/deps.nix
@@ -1,12 +1,13 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 let
   inherit (lib) mapAttrs recursiveUpdate;
+  inherit (lib) subImport; # Custom
 
   # Plugins/libraries and their dependencies should be put here.
 
   # We need to fill in the attrset with dummy values for libraries and plugins that don't have deps due to how getDeps works
-  supportedLibraries = import ./libraries/libraries.nix { inherit lib pkgs; };
-  supportedPlugins = import ./plugins/plugins.nix { inherit lib pkgs; };
+  supportedLibraries = subImport ./libraries/libraries.nix;
+  supportedPlugins = subImport ./plugins/plugins.nix;
 
   templateLibraryDeps = mapAttrs (_: _: {
     libraries = [ ];

--- a/modules/libraries/pack.nix
+++ b/modules/libraries/pack.nix
@@ -1,36 +1,15 @@
 { config, lib, ... }:
 let
-  inherit (lib) getAttrs attrNames subtractLists flatten mergeAttrsList;
-  inherit (lib) subImport mapGetDeps; # Custom
+  inherit (lib) unique getAttrs mergeAttrsList;
+  inherit (lib) subImport; # Custom
   cfg = config.programs.lite-xl;
-
-  supportedLibraries = subImport ./libraries.nix;
-  depsList = subImport ../deps.nix;
 
   customEnableList = cfg.libraries.customEnableList;
 
-  # Filter enabled libraries
-  libraryEnableList = cfg.libraries.enableList;
-  librariesWithDepsStrings = attrNames (getAttrs libraryEnableList depsList.libraries);
+  supportedLibraries = subImport ./libraries.nix;
+  resolvedDeps = unique (subImport ../resolve.nix).libraries;
 
-  # Get library deps
-  libraryDeps = mapGetDeps librariesWithDepsStrings (dep: _: depsList.libraries.${dep}.libraries);
-
-  # Filter enabled plugins
-  # Plugins can depend on libraries so we need to check those too
-  pluginEnableList = cfg.plugins.enableList;
-  pluginsWithDepsStrings = attrNames (getAttrs pluginEnableList depsList.plugins);
-
-  # Get plugin library deps
-  pluginLibraryDeps = subtractLists pluginsWithDepsStrings (mapGetDeps pluginsWithDepsStrings (dep: acc:
-    ### This actually does not catch libraries from exclusively resolved plugins (plugins not in enableList). This will be addressed in the future
-    # Get the libraries from the plugin first, then from those libraries' libraries going forward
-    if acc == [ ]
-    then depsList.plugins.${dep}.libraries
-    else depsList.libraries.${dep}.libraries
-  ));
-
-  finalLibraries = getAttrs (flatten [ libraryDeps pluginLibraryDeps ]) supportedLibraries;
+  finalLibraries = getAttrs resolvedDeps supportedLibraries;
 in
 mergeAttrsList [
   finalLibraries

--- a/modules/plugins/pack.nix
+++ b/modules/plugins/pack.nix
@@ -1,24 +1,15 @@
 { config, lib, ... }:
 let
-  inherit (lib) getAttrs attrNames flatten mergeAttrsList;
-  inherit (lib) subImport mapGetDeps; # Custom
+  inherit (lib) unique getAttrs mergeAttrsList;
+  inherit (lib) subImport; # Custom
   cfg = config.programs.lite-xl;
-
-  supportedPlugins = subImport ./plugins.nix;
-  depsList = subImport ../deps.nix;
 
   customEnableList = cfg.plugins.customEnableList;
 
-  # Filter enabled plugins
-  enableList = cfg.plugins.enableList;
-  pluginsWithDepsStrings = attrNames (getAttrs enableList depsList.plugins);
+  supportedPlugins = subImport ./plugins.nix;
+  resolvedDeps = unique (subImport ../resolve.nix).plugins;
 
-  # Get plugins deps
-  pluginDeps = mapGetDeps pluginsWithDepsStrings (dep: _: depsList.plugins.${dep}.plugins);
-
-  # Ignore checking if any supported library depends on a plugin because currently none do and will likely never
-
-  finalPlugins = getAttrs (flatten pluginDeps) supportedPlugins;
+  finalPlugins = getAttrs resolvedDeps supportedPlugins;
 in
 mergeAttrsList [
   finalPlugins

--- a/modules/resolve.nix
+++ b/modules/resolve.nix
@@ -1,0 +1,62 @@
+{ config, lib, ... }:
+let
+  inherit (lib) foldl' flatten;
+  inherit (lib) subImport; # Custom
+  cfg = config.programs.lite-xl;
+
+  depsList = subImport ./deps.nix;
+
+  pluginEnableList = cfg.plugins.enableList;
+  libraryEnableList = cfg.libraries.enableList;
+
+  collapseTree = tree:
+    if lib.isList tree.plugins
+    then tree
+    else let
+      next = tree.plugins;
+      newTree = {
+        libraries = tree.libraries ++ next.libraries;
+        plugins = next.plugins;
+      };
+    in collapseTree newTree;    
+
+  getDeps = item: type: p-acc: l-acc:
+    let
+      nextPlugins = depsList.${type}.${item}.plugins;
+      nextLibraries = depsList.${type}.${item}.libraries;
+    in
+      if type == "plugins"
+      then let
+        # Accumulate dependencies from each recursion iteration
+        accPlugins = (
+          if lib.isList p-acc
+          then p-acc ++ [ item ]
+          else (collapseTree p-acc).plugins ++ [ item ]
+        );
+        accLibraries = l-acc;
+      in {
+        plugins = foldl' (acc: dep: getDeps dep "plugins" acc accLibraries) accPlugins nextPlugins;
+        libraries = foldl' (acc: dep: getDeps dep "libraries" accPlugins acc) accLibraries nextLibraries;
+      } else let
+        # Libraries likely shouldn't depend on plugins so we skip checking for that
+        # If this is implemented, then collapseTree would need to be refactored
+        accLibraries = l-acc ++ [ item ];
+      in
+      foldl' (acc: dep: getDeps dep "libraries" p-acc accLibraries) accLibraries nextLibraries;
+
+  resolveDeps = plugin: type: collapseTree (lib.head (flatten (getDeps plugin type [ ] [ ])));
+
+  mergeDeps = list:
+    lib.foldAttrs (item: acc: item ++ acc) [ ] list;
+
+  mapResolveDeps = items: type:
+    mergeDeps (map (item: (resolveDeps item type)) items);
+
+  resolvedPlugins = mapResolveDeps pluginEnableList "plugins";
+  resolvedLibraries = mapResolveDeps libraryEnableList "libraries";
+in
+mergeDeps [
+  resolvedPlugins
+  resolvedLibraries
+]
+


### PR DESCRIPTION
This now can actually resolve all deps properly, even from exclusively recursed deps (deps not in enableList)